### PR TITLE
Make main and cli modules directly executable

### DIFF
--- a/rsocks/__init__.py
+++ b/rsocks/__init__.py
@@ -1,1 +1,5 @@
 __version__ = '0.3.3'
+
+if __name__ == '__main__':
+    import cli
+    cli.main()

--- a/rsocks/cli.py
+++ b/rsocks/cli.py
@@ -52,3 +52,6 @@ def main(context, config):
             server.listen((listen_host, listen_port))
 
     pool.loop()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Examples: `python3 -m rsocks`, `python3 -m rsocks.cli`. Took me a while to figure out that this wasn't possible :-)